### PR TITLE
feat: enforce NSFW channel restriction for /imagine with warning

### DIFF
--- a/cogs/imagine.py
+++ b/cogs/imagine.py
@@ -223,7 +223,7 @@ class ImagineCog(commands.Cog):
                 description="This bot can generate NSFW content. For safety reasons, the `/imagine` command can only be used in channels marked as NSFW.",
                 color=discord.Color.orange()
             )
-            await interaction.followup.send(embed=embed, ephemeral=True)
+            await interaction.followup.send(embed=embed)
             return
 
         # Global queue limit

--- a/cogs/imagine.py
+++ b/cogs/imagine.py
@@ -220,7 +220,7 @@ class ImagineCog(commands.Cog):
             embed = discord.Embed(
                 title="⚠️ NSFW Restriction",
                 description="This bot can generate NSFW content. For safety reasons, the `/imagine` command can only be used in channels marked as NSFW.",
-                color=discord.Color.orange()
+                color=discord.Color(value=0xffcc4d)
             )
             embed.set_footer(text="This message will auto-delete in 10 seconds.")
             await interaction.response.send_message(embed=embed, delete_after=10)

--- a/cogs/imagine.py
+++ b/cogs/imagine.py
@@ -216,6 +216,16 @@ class ImagineCog(commands.Cog):
     ):
         await interaction.response.defer(ephemeral=False)
 
+        # Restrict use to NSFW channels only
+        if not (isinstance(interaction.channel, discord.TextChannel) and interaction.channel.is_nsfw()):
+            embed = discord.Embed(
+                title="⚠️ NSFW Restriction",
+                description="This bot can generate NSFW content. For safety reasons, the `/imagine` command can only be used in channels marked as NSFW.",
+                color=discord.Color.orange()
+            )
+            await interaction.followup.send(embed=embed, ephemeral=True)
+            return
+
         # Global queue limit
         if image_queue.qsize() >= 10:
             await interaction.followup.send(

--- a/cogs/imagine.py
+++ b/cogs/imagine.py
@@ -222,8 +222,8 @@ class ImagineCog(commands.Cog):
                 description="This bot can generate NSFW content. For safety reasons, the `/imagine` command can only be used in channels marked as NSFW.",
                 color=discord.Color(value=0xffcc4d)
             )
-            embed.set_footer(text="This message will auto-delete in 10 seconds.")
-            await interaction.response.send_message(embed=embed, delete_after=10)
+            embed.set_footer(text="This message will auto-delete in 30 seconds.")
+            await interaction.response.send_message(embed=embed, delete_after=30)
             return
 
         await interaction.response.defer(ephemeral=False)

--- a/cogs/imagine.py
+++ b/cogs/imagine.py
@@ -214,7 +214,6 @@ class ImagineCog(commands.Cog):
         height: Optional[int] = None,
         seed: Optional[int] = None,
     ):
-        await interaction.response.defer(ephemeral=False)
 
         # Restrict use to NSFW channels only
         if not (isinstance(interaction.channel, discord.TextChannel) and interaction.channel.is_nsfw()):
@@ -223,8 +222,11 @@ class ImagineCog(commands.Cog):
                 description="This bot can generate NSFW content. For safety reasons, the `/imagine` command can only be used in channels marked as NSFW.",
                 color=discord.Color.orange()
             )
-            await interaction.followup.send(embed=embed)
+            embed.set_footer(text="This message will auto-delete in 10 seconds.")
+            await interaction.response.send_message(embed=embed, delete_after=10)
             return
+
+        await interaction.response.defer(ephemeral=False)
 
         # Global queue limit
         if image_queue.qsize() >= 10:


### PR DESCRIPTION
Restricts /imagine to NSFW channels. Sends a warning as an embed that auto-deletes after 30s if used in a non-NSFW channel.